### PR TITLE
Removed duplicate code

### DIFF
--- a/pkg/storage/redis.go
+++ b/pkg/storage/redis.go
@@ -92,12 +92,7 @@ func (s *RedisStore) UpdateEndpoint(id uuid.UUID, params UpdateEndpointParams) e
 	if len(params.Deploys) > 0 {
 		endpoint.DeployHistory = append(endpoint.DeployHistory, params.Deploys...)
 	}
-	b, err := msgpack.Marshal(endpoint)
-	if err != nil {
-		return err
-	}
-	key := makeKey("endpoint", endpoint.ID)
-	return s.client.Set(context.Background(), key, b, 0).Err()
+	return s.CreateEndpoint(endpoint)
 }
 
 func (s *RedisStore) GetDeploy(id uuid.UUID) (*types.Deploy, error) {


### PR DESCRIPTION
A very small change on the code that updates the endpoint in redis.

Since the used code was the same as `CreateEndpoint` function, it made sense to me use that function instead of having duplicate lines