### PR TITLE
Recompiled spidermonkey so we do not need to hex encode stdout

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -55,7 +55,7 @@ func main() {
 }
 
 func seedEndpoint(store storage.Store, cache storage.ModCacher) {
-	b, err := os.ReadFile("examples/go/app.wasm")
+	b, err := os.ReadFile("examples/js/index.js")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/go/main.go
+++ b/examples/go/main.go
@@ -17,9 +17,15 @@ func handleDashboard(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte("hello from the dashboard handler"))
 }
 
+func handleIndex(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("login page: <a href=\"/login\" /><br />Dashboard page: <a href=\"/dashboard\" />"))
+}
+
 func main() {
 	router := chi.NewMux()
 	router.Get("/dashboard", handleDashboard)
 	router.Get("/login", handleLogin)
+	router.Get("/", handleIndex)
 	raptor.Handle(router)
 }

--- a/examples/js/index.js
+++ b/examples/js/index.js
@@ -1,32 +1,19 @@
 // This should come from the official SDK.
 // But there is no official SDK yet, so we keep it here.
-function hexLog(s) {
-    for (let i = 0; i < s.length; i++) {
-        putstr(s.charCodeAt(i).toString(16).padStart(2, "0"))
-    }
-    putstr("0a")
-}
-
-console.log = hexLog
-
 function respond(res, status) {
     var buffer = new ArrayBuffer(8);
     var view = new DataView(buffer);
     view.setUint32(0, status, true);
     view.setUint32(4, res.length, true);
 
-    for (let i = 0; i < res.length; i++) {
-        putstr(res.charCodeAt(i).toString(16).padStart(2, "0"))
-    }
-    for (let i = 0; i < view.buffer.byteLength; i++) {
-        putstr(view.getUint8(i).toString(16).padStart(2, "0"));
-    }
+    putstr(res);
+    writebytes(view)
 }
 
-console.log("user log here")
-console.log("user log here")
-console.log("user log here")
-console.log("user log here")
-console.log("user log here")
+console.log("USER LOGS");
+console.log("USER LOGS");
+console.log("USER LOGS");
+console.log("USER LOGS");
+console.log("USER LOGS");
 
-respond("<h1>From my Raptor application</h1></br>some other stuff here</br>", 200)
+respond("Hello world!", 200)

--- a/internal/_testdata/helloworld.js
+++ b/internal/_testdata/helloworld.js
@@ -1,26 +1,19 @@
 // This should come from the official SDK.
 // But there is no official SDK yet, so we keep it here.
-function hexLog(s) {
-    for (let i = 0; i < s.length; i++) {
-        putstr(s.charCodeAt(i).toString(16).padStart(2, "0"))
-    }
-    putstr("0a")
-}
-
-console.log = hexLog
-
 function respond(res, status) {
     var buffer = new ArrayBuffer(8);
     var view = new DataView(buffer);
     view.setUint32(0, status, true);
     view.setUint32(4, res.length, true);
 
-    for (let i = 0; i < res.length; i++) {
-        putstr(res.charCodeAt(i).toString(16).padStart(2, "0"))
-    }
-    for (let i = 0; i < view.buffer.byteLength; i++) {
-        putstr(view.getUint8(i).toString(16).padStart(2, "0"));
-    }
+    putstr(res);
+    writebytes(view)
 }
+
+console.log("USER LOGS");
+console.log("USER LOGS");
+console.log("USER LOGS");
+console.log("USER LOGS");
+console.log("USER LOGS");
 
 respond("Hello world!", 200)

--- a/internal/actrs/runtime.go
+++ b/internal/actrs/runtime.go
@@ -145,7 +145,7 @@ func (r *Runtime) handleHTTPRequest(ctx *actor.Context, msg *proto.HTTPRequest) 
 		return
 	}
 
-	logs, res, status, err := shared.ParseStdout(msg.Runtime, r.stdout)
+	logs, res, status, err := shared.ParseStdout(r.stdout)
 	if err != nil {
 		respondError(ctx, http.StatusInternalServerError, "invalid response", msg.ID)
 		return

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -42,7 +42,7 @@ func TestRuntimeInvokeJSCode(t *testing.T) {
 	scriptArgs := []string{"", "-e", string(b)}
 	require.Nil(t, r.Invoke(bytes.NewReader(breq), nil, scriptArgs...))
 
-	_, res, status, err := shared.ParseStdout("js", out)
+	_, res, status, err := shared.ParseStdout(out)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 	require.Equal(t, "Hello world!", string(res))
@@ -72,7 +72,7 @@ func TestRuntimeInvokeGoCode(t *testing.T) {
 	r, err := New(context.Background(), args)
 	require.Nil(t, err)
 	require.Nil(t, r.Invoke(bytes.NewReader(breq), nil))
-	_, res, status, err := shared.ParseStdout("go", out)
+	_, res, status, err := shared.ParseStdout(out)
 	require.Nil(t, err)
 	require.Equal(t, http.StatusOK, status)
 	require.Equal(t, "Hello world!", string(res))

--- a/internal/shared/shared.go
+++ b/internal/shared/shared.go
@@ -21,8 +21,8 @@ const (
 
 var errInvalidHTTPResponse = errors.New("invalid HTTP response")
 
-func ParseStdout(runtime string, stdout io.Reader) (logs []byte, resp []byte, status int, err error) {
-	stdoutb, err := io.ReadAll(GetDecodedStdout(runtime, stdout))
+func ParseStdout(stdout io.Reader) (logs []byte, resp []byte, status int, err error) {
+	stdoutb, err := io.ReadAll(stdout)
 	if err != nil {
 		return
 	}
@@ -91,17 +91,6 @@ func makeProtoHeader(header http.Header) map[string]*proto.HeaderFields {
 		}
 	}
 	return m
-}
-
-func GetDecodedStdout(runtime string, stdout io.Reader) io.Reader {
-	switch runtime {
-	case "go":
-		return stdout
-	case "js":
-		return hex.NewDecoder(stdout)
-	default:
-		return stdout
-	}
 }
 
 func IsZeroUUID(id uuid.UUID) bool {

--- a/internal/shared/shared_test.go
+++ b/internal/shared/shared_test.go
@@ -34,7 +34,7 @@ the big brown fox
 		builder.WriteString(userLogs)
 		builder.WriteString(userResp)
 		builder.Write(buf)
-		if _, _, _, err := ParseStdout("go", builder); err != nil {
+		if _, _, _, err := ParseStdout(builder); err != nil {
 			log.Fatal(err)
 		}
 		builder.Reset()
@@ -54,7 +54,7 @@ func TestParseWithoutUserLogs(t *testing.T) {
 	binary.LittleEndian.PutUint32(buf[4:8], uint32(len(userResp)))
 	builder.Write(buf)
 
-	logs, resp, status, err := ParseStdout("go", builder)
+	logs, resp, status, err := ParseStdout(builder)
 	require.Nil(t, err)
 	require.Equal(t, int(statusCode), status)
 	require.Equal(t, userResp, string(resp))
@@ -81,7 +81,7 @@ the big brown fox
 	binary.LittleEndian.PutUint32(buf[4:8], uint32(len(userResp)))
 	builder.Write(buf)
 
-	logs, resp, status, err := ParseStdout("go", builder)
+	logs, resp, status, err := ParseStdout(builder)
 	require.Nil(t, err)
 	require.Equal(t, int(statusCode), status)
 	require.Equal(t, userResp, string(resp))


### PR DESCRIPTION
Added new function to js shell, called `writebytes`. Expects `MemoryView` or `Uint8Array`

Changes of engine could be found [here](https://github.com/bakhangildin/spidermonkey/commit/c96e2cef91e975d34b867a936954fe5f7c6f850b)

Also found some problem with go example. Error in logs
```
2024/01/13 21:45:21 WARN runtime invoke error err="args invalid: contains NUL character"
```